### PR TITLE
Backend/api mogu post my

### DIFF
--- a/app/api/api_messages.py
+++ b/app/api/api_messages.py
@@ -11,3 +11,4 @@ MOGU_POST_UPDATE_FORBIDDEN = "모구 게시물을 수정할 권한이 없습니�
 MOGU_POST_UPDATE_NOT_ALLOWED = "현재 상태에서는 모구 게시물을 수정할 수 없습니다"
 MOGU_POST_DELETE_FORBIDDEN = "모구 게시물을 삭제할 권한이 없습니다"
 MOGU_POST_DELETE_NOT_ALLOWED = "현재 상태에서는 모구 게시물을 삭제할 수 없습니다"
+INVALID_STATUS_VALUE = "유효하지 않은 상태 값입니다"


### PR DESCRIPTION
# 🚀 내 게시물/참여 목록 API

## 📋 **개요**
사용자가 자신이 작성한 모구 게시물과 참여한 모구 게시물을 조회할 수 있는 API를 구현했습니다.

## ✨ **주요 기능**

### 🏠 **새로 구현된 API**

1. **내가 작성한 게시물 목록**
   - **Endpoint**: `GET /mogu-posts/my-posts`
   - **기능**: 현재 사용자가 작성한 모든 모구 게시물 조회
   - **필터링**: 상태별 필터링 (recruiting, pending, completed, canceled, locked)
   - **정렬**: 최신순 (생성일 기준)
   - **페이지네이션**: page, size 파라미터 지원

2. **내가 참여한 게시물 목록**
   - **Endpoint**: `GET /mogu-posts/my-participations`
   - **기능**: 현재 사용자가 참여한 모든 모구 게시물 조회
   - **필터링**: 참여 상태별 필터링 (applied, accepted, rejected, canceled, no_show, fulfilled)
   - **정렬**: 참여 신청일 최신순
   - **페이지네이션**: page, size 파라미터 지원

## 🗄️ **데이터베이스 쿼리 최적화**

### **내가 작성한 게시물 조회**
```sql
SELECT * FROM mogu_post 
WHERE user_id = ? 
ORDER BY created_at DESC 
LIMIT ? OFFSET ?
```

### **내가 참여한 게시물 조회**
```sql
SELECT mp.*, p.* FROM mogu_post mp
JOIN participation p ON mp.id = p.mogu_post_id
WHERE p.user_id = ?
ORDER BY p.applied_at DESC
LIMIT ? OFFSET ?
```

## 🔧 **기술적 구현**

### **PostGIS 지리 정보 처리**
- `geoalchemy2.shape.to_shape`를 통한 좌표 추출
- 위도/경도 정보를 응답에 포함

#### **N+1 쿼리 방지**
- `selectinload(MoguPost.images)` 사용
- `selectinload(MoguPost.user)` 사용
- 효율적인 조인 쿼리 구현

#### **페이지네이션**
- 전체 개수 조회를 위한 별도 쿼리
- `has_next` 플래그로 다음 페이지 존재 여부 확인

## 📊 **API 응답 예시**

### **내가 작성한 게시물 목록**
```json
{
  "items": [
    {
      "id": "uuid",
      "title": "코스트코에서 생수 24팩 같이 구매하실 분?",
      "price": 25000,
      "category": "food",
      "mogu_market": "emart",
      "mogu_spot": {"latitude": 37.5665, "longitude": 126.978},
      "mogu_datetime": "2024-01-15T14:00:00Z",
      "status": "recruiting",
      "target_count": 4,
      "joined_count": 2,
      "created_at": "2024-01-10T10:00:00Z",
      "user": {"user_id": "uuid", "nickname": "모구장"},
      "my_participation": null,
      "is_favorited": false
    }
  ],
  "total": 10,
  "page": 1,
  "size": 20,
  "has_next": false
}
```

### **내가 참여한 게시물 목록**
```json
{
  "items": [
    {
      "id": "uuid",
      "title": "모구 게시물 제목",
      "price": 25000,
      "category": "food",
      "mogu_market": "emart",
      "mogu_spot": {"latitude": 37.5665, "longitude": 126.978},
      "mogu_datetime": "2024-01-15T14:00:00Z",
      "status": "recruiting",
      "target_count": 4,
      "joined_count": 2,
      "created_at": "2024-01-10T10:00:00Z",
      "user": {"user_id": "uuid", "nickname": "모구장"},
      "my_participation": {
        "status": "accepted",
        "applied_at": "2024-01-11T09:00:00Z"
      },
      "is_favorited": false
    }
  ],
  "total": 5,
  "page": 1,
  "size": 20,
  "has_next": false
}
```

## 📝 **문서화**
- Notion API 명세 업데이트
- Query Parameters 상세 설명 추가
- Response Body 예시 포함

## 📈 **성능 고려사항**
- 데이터베이스 인덱스 활용
- 효율적인 조인 쿼리
- 페이지네이션을 통한 메모리 최적화

### 🚨 **해결된 이슈**
- **라우터 순서 문제**: 404 오류 해결