### PR TITLE
Backend/fix api mogu post

### DIFF
--- a/app/enums.py
+++ b/app/enums.py
@@ -45,7 +45,7 @@ class MarketEnum(str, enum.Enum):
 
 
 class PostStatusEnum(str, enum.Enum):
-    """게시글 상태 (향후 사용)"""
+    """게시글 상태"""
 
     DRAFT = "draft"
     RECRUITING = "recruiting"
@@ -57,7 +57,7 @@ class PostStatusEnum(str, enum.Enum):
 
 
 class ParticipationStatusEnum(str, enum.Enum):
-    """참여 상태 (향후 사용)"""
+    """참여 상태"""
 
     APPLIED = "applied"
     ACCEPTED = "accepted"

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -159,7 +159,7 @@ class MoguPostListQueryParams(BaseRequest):
     sort: str = "ai_recommended"
     category: str | None = None
     mogu_market: str | None = None
-    status: str | None = None
-    latitude: float | None = None
-    longitude: float | None = None
+    status: str | None = "recruiting"  # 기본값은 recruiting, None이면 모든 상태 조회
+    latitude: float  # 필수 파라미터로 변경
+    longitude: float  # 필수 파라미터로 변경
     radius: float = 3.0

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -127,6 +127,17 @@ class MoguPostParticipationResponse(BaseResponse):
     joined_at: datetime | None = None
 
 
+class QuestionAnswerResponse(BaseResponse):
+    id: str
+    questioner_id: str
+    question: str
+    answerer_id: str | None = None
+    answer: str | None = None
+    is_private: bool
+    question_created_at: datetime
+    answer_created_at: datetime | None = None
+
+
 class MoguPostResponse(BaseResponse):
     id: str
     user_id: str
@@ -145,31 +156,26 @@ class MoguPostResponse(BaseResponse):
     user: dict[str, str | None]
     my_participation: dict[str, Any] | None = None
     is_favorited: bool | None = None
+    questions_answers: list[dict[str, Any]] | None = None
 
 
-class MoguPostListResponse(BaseResponse):
+class MoguPostListItemResponse(BaseResponse):
+    """모구 게시물 목록용 최적화된 응답 스키마"""
+
     id: str
-    user_id: str
     title: str
-    description: str | None = None
     price: int
     category: str
     mogu_market: str
-    mogu_spot: dict[str, float]
     mogu_datetime: datetime
     status: str
-    target_count: int | None = None
+    target_count: int
     joined_count: int
     created_at: datetime
-    images: list[dict[str, Any]] | None = None
-    user: dict[str, str | None]
-    my_participation: dict[str, Any] | None = None
-    is_favorited: bool | None = None
+    thumbnail_image: str | None = None
+    favorite_count: int  # 찜하기 개수
 
 
 class MoguPostListPaginatedResponse(BaseResponse):
-    items: list[MoguPostListResponse]
-    total: int
-    page: int
-    size: int
-    has_next: bool
+    posts: list[MoguPostListItemResponse]
+    pagination: dict[str, int]

--- a/docs/dbdiagram-erd
+++ b/docs/dbdiagram-erd
@@ -45,22 +45,22 @@ Enum user_status_enum {
 }
 
 Enum post_status_enum {
-  draft
-  recruiting
-  locked
-  purchasing
-  distributing
-  completed
-  canceled
+  draft         // 임시 저장 (아직 게시되지 않음)
+  recruiting    // 모집중 (참여자 모집 중)
+  locked        // 잠금 (모집 완료, 거래 시작 전)
+  purchasing    // 구매중 (실제 구매 진행 중)
+  distributing   // 분배중 (구매 완료 후 분배 진행 중)
+  completed     // 완료
+  canceled      // 취소
 }
 
 Enum participation_status_enum {
-  applied
-  accepted
-  rejected
-  canceled
-  no_show
-  fulfilled
+  applied    // 신청
+  accepted   // 승인
+  rejected   // 거절
+  canceled   // 취소
+  no_show    // 불참
+  fulfilled  // 완료
 }
 
 Enum rating_keyword_type_enum {


### PR DESCRIPTION
# 📝 모구글 목록/상세 API 리팩터링 및 Q&A, 썸네일, 즐겨찾기 카운트 추가

## 📌 개요

모구 게시글(`mogu_posts`) 관련 API를 전면 리팩터링했습니다.
목록 응답 구조를 단순화하고, 썸네일/즐겨찾기 수 등을 추가하여 클라이언트 표시용으로 최적화했습니다.
또한 상세 조회에 Q&A(`questions_answers`) 정보를 포함시켰습니다.

## ✅ 주요 변경 사항

### 1. **목록 API (`get_mogu_posts`)**

* 응답 모델을 `MoguPostListItemResponse`로 단순화
* 불필요한 필드 제거: `description`, `images`, `user`, `my_participation`, `is_favorited`, `mogu_spot`
* 추가 필드:

  * `thumbnail_image`: 썸네일 지정 이미지 or 첫 번째 이미지
  * `favorite_count`: 즐겨찾기 수
* 페이징 구조 변경
  기존:

  ```json
  { "items": [...], "total": 50, "page": 1, "size": 10, "has_next": true }
  ```

  변경:

  ```json
  { "posts": [...], "pagination": { "page": 1, "limit": 10, "total": 50, "total_pages": 5 } }
  ```
* 거리 필터 및 정렬(PostGIS) 고정 적용
* `status` 기본값을 `"recruiting"`으로 설정

### 2. **내 게시글 / 내 참여글 API**

* 동일한 응답 스키마(`MoguPostListItemResponse`)로 통일
* 즐겨찾기 수 및 썸네일 로직 동일하게 적용
* 좌표 및 유저 정보 필드 제거

### 3. **상세 조회 (`get_mogu_post`)**

* Q&A(`questions_answers`) 목록 추가
  → 질문자/답변자, 질문/답변 내용, 공개 여부, 생성일 등 포함
* 관련 로딩을 위해 `selectinload(MoguPost.questions_answers)` 추가

### 4. **스키마 변경**

* `MoguPostListResponse` → `MoguPostListItemResponse`로 변경
* `MoguPostListPaginatedResponse` 구조 변경
* `MoguPostListQueryParams`에서 `latitude`, `longitude`를 필수로 변경

### 5. **기타**

* `PostStatusEnum`, `ParticipationStatusEnum` 주석 정리
* 불필요한 `user` eager loading 제거

## ⚠️ BREAKING CHANGES

* **응답 구조 변경**

  * 목록 응답: `items` → `posts`, `total/page/size/has_next` → `pagination`
* **요청 파라미터 변경**

  * `latitude`, `longitude`가 필수 파라미터로 변경됨
* **필드 제거**

  * `user`, `description`, `images`, `is_favorited`, `mogu_spot`, `my_participation` 등 제거
* **클라이언트 수정 필요**

  * 목록 렌더링 로직 및 페이징 처리 로직 업데이트 필요

## 🧾 참고

* 이 변경은 **클라이언트 UI 표시 최적화 및 중복 데이터 정리**를 목표로 합니다.
* 이후 Q&A CRUD 및 즐겨찾기 API 통합 작업에서 재사용될 예정입니다.
