### PR TITLE
Backend/api participations

### DIFF
--- a/app/api/api_router.py
+++ b/app/api/api_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from app.api import api_messages
-from app.api.endpoints import auth, mogu_posts, users
+from app.api.endpoints import auth, mogu_posts, participations, users
 
 auth_router = APIRouter()
 auth_router.include_router(auth.router, prefix="/auth", tags=["auth"])
@@ -33,3 +33,6 @@ api_router = APIRouter(
 )
 api_router.include_router(users.router, prefix="/users", tags=["users"])
 api_router.include_router(mogu_posts.router, prefix="/mogu-posts", tags=["mogu-posts"])
+api_router.include_router(
+    participations.router, prefix="/mogu-posts", tags=["participations"]
+)

--- a/app/api/endpoints/mogu_posts.py
+++ b/app/api/endpoints/mogu_posts.py
@@ -1,3 +1,5 @@
+from datetime import datetime
+
 from fastapi import APIRouter, Depends, HTTPException
 from geoalchemy2.shape import from_shape, to_shape
 from shapely.geometry import Point
@@ -18,9 +20,43 @@ from app.schemas.responses import (
     MoguPostListItemResponse,
     MoguPostListPaginatedResponse,
     MoguPostResponse,
+    MoguPostWithParticipationPaginatedResponse,
+    MoguPostWithParticipationResponse,
 )
 
 router = APIRouter()
+
+
+async def _handle_post_status_change(
+    mogu_post: MoguPost,
+    original_status: PostStatusEnum,
+    new_status: PostStatusEnum,
+    session: AsyncSession,
+) -> None:
+    """모구 게시물 상태 변경 시 참여자들의 상태를 적절히 처리합니다."""
+
+    # 게시물이 취소되거나 완료된 경우 참여자 상태 처리
+    if new_status in [PostStatusEnum.CANCELED, PostStatusEnum.COMPLETED]:
+        # 모든 참여자 조회
+        participants_query = select(Participation).where(
+            Participation.mogu_post_id == mogu_post.id
+        )
+        participants_result = await session.execute(participants_query)
+        participants = participants_result.scalars().all()
+
+        for participation in participants:
+            # ACCEPTED 상태의 참여자들만 처리
+            if participation.status == ParticipationStatusEnum.ACCEPTED:
+                if new_status == PostStatusEnum.CANCELED:
+                    # 게시물 취소 시: ACCEPTED → CANCELED
+                    participation.status = ParticipationStatusEnum.CANCELED
+                    participation.decided_at = datetime.utcnow()
+                    # joined_count 감소
+                    mogu_post.joined_count -= 1
+                elif new_status == PostStatusEnum.COMPLETED:
+                    # 게시물 완료 시: ACCEPTED → FULFILLED
+                    participation.status = ParticipationStatusEnum.FULFILLED
+                    participation.decided_at = datetime.utcnow()
 
 
 @router.post("/", response_model=MoguPostResponse, description="모구 게시물 생성")
@@ -335,7 +371,7 @@ async def get_my_posts(
 
 @router.get(
     "/my-participations",
-    response_model=MoguPostListPaginatedResponse,
+    response_model=MoguPostWithParticipationPaginatedResponse,
     description="내가 참여한 게시물 목록",
 )
 async def get_my_participations(
@@ -344,7 +380,7 @@ async def get_my_participations(
     size: int = 20,
     current_user: User = Depends(deps.get_current_user),
     session: AsyncSession = Depends(get_async_session),
-) -> MoguPostListPaginatedResponse:
+) -> MoguPostWithParticipationPaginatedResponse:
     """내가 참여한 모구 게시물 목록을 조회합니다."""
 
     # 기본 쿼리 구성 (참여 테이블과 조인)
@@ -383,7 +419,7 @@ async def get_my_participations(
     rows = result.all()
 
     # 응답 데이터 구성
-    posts_list = []
+    posts_list: list[MoguPostWithParticipationResponse] = []
     for post, participation in rows:
         # 찜하기 개수 조회
         favorite_count_query = (
@@ -406,7 +442,7 @@ async def get_my_participations(
                 thumbnail_image = post.images[0].image_url
 
         posts_list.append(
-            MoguPostListItemResponse(
+            MoguPostWithParticipationResponse(
                 id=post.id,
                 title=post.title,
                 price=post.price,
@@ -423,10 +459,14 @@ async def get_my_participations(
                 created_at=post.created_at,
                 thumbnail_image=thumbnail_image,
                 favorite_count=favorite_count,
+                # 참여 상태 정보
+                my_participation_status=participation.status,
+                my_participation_applied_at=participation.applied_at,
+                my_participation_decided_at=participation.decided_at,
             )
         )
 
-    return MoguPostListPaginatedResponse(
+    return MoguPostWithParticipationPaginatedResponse(
         posts=posts_list,
         pagination={
             "page": page,
@@ -607,9 +647,21 @@ async def update_mogu_post(
             Point(mogu_spot["longitude"], mogu_spot["latitude"]), srid=4326
         )
 
+    # 상태 변경 전 원래 상태 저장
+    original_status = mogu_post.status
+
     for field, value in update_data.items():
         if field != "images" and hasattr(mogu_post, field):
             setattr(mogu_post, field, value)
+
+    # 모구 게시물 상태가 변경된 경우 참여자 상태 처리
+    if "status" in update_data and original_status != mogu_post.status:
+        await _handle_post_status_change(
+            mogu_post,
+            PostStatusEnum(original_status),
+            PostStatusEnum(mogu_post.status),
+            session,
+        )
 
     # 이미지 업데이트 (기존 이미지 삭제 후 새로 추가)
     if "images" in update_data:

--- a/app/api/endpoints/participations.py
+++ b/app/api/endpoints/participations.py
@@ -1,0 +1,298 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api import api_messages, deps
+from app.core.database_session import get_async_session
+from app.enums import ParticipationStatusEnum, PostStatusEnum
+from app.models import MoguPost, Participation, User
+from app.schemas.requests import ParticipationStatusUpdateRequest
+from app.schemas.responses import (
+    ParticipationListResponse,
+    ParticipationMessageResponse,
+    ParticipationResponse,
+    ParticipationWithUserResponse,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/{post_id}/participate",
+    response_model=ParticipationMessageResponse,
+    description="참여 요청",
+)
+async def participate_mogu_post(
+    post_id: str,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> ParticipationMessageResponse:
+    """모구 게시물에 참여 요청합니다."""
+
+    # 게시물 조회
+    query = select(MoguPost).where(MoguPost.id == post_id)
+    result = await session.execute(query)
+    mogu_post = result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    # 모집 가능한 상태인지 확인
+    if mogu_post.status != PostStatusEnum.RECRUITING:
+        raise HTTPException(
+            status_code=400,
+            detail="현재 모집 중이 아닙니다.",
+        )
+
+    # 작성자는 참여할 수 없음
+    if mogu_post.user_id == current_user.id:
+        raise HTTPException(
+            status_code=400,
+            detail="게시물 작성자는 참여할 수 없습니다.",
+        )
+
+    # 이미 참여 신청했는지 확인
+    existing_participation_query = select(Participation).where(
+        and_(
+            Participation.mogu_post_id == post_id,
+            Participation.user_id == current_user.id,
+        )
+    )
+    existing_result = await session.execute(existing_participation_query)
+    existing_participation = existing_result.scalar_one_or_none()
+
+    if existing_participation:
+        if existing_participation.status in [
+            ParticipationStatusEnum.APPLIED,
+            ParticipationStatusEnum.ACCEPTED,
+        ]:
+            raise HTTPException(
+                status_code=400,
+                detail="이미 참여 신청하거나 승인된 상태입니다.",
+            )
+        elif existing_participation.status == ParticipationStatusEnum.REJECTED:
+            raise HTTPException(
+                status_code=400,
+                detail="거절된 참여 신청입니다.",
+            )
+
+    # 새로운 참여 요청 생성
+    participation = Participation(
+        mogu_post_id=post_id,
+        user_id=current_user.id,
+        status=ParticipationStatusEnum.APPLIED,
+        applied_at=datetime.utcnow(),
+    )
+
+    session.add(participation)
+    await session.commit()
+    await session.refresh(participation)
+
+    return ParticipationMessageResponse(
+        message="참여 요청이 완료되었습니다.",
+        participation=ParticipationResponse(
+            user_id=participation.user_id,
+            mogu_post_id=participation.mogu_post_id,
+            status=participation.status,
+            applied_at=participation.applied_at,
+            decided_at=participation.decided_at,
+        ),
+    )
+
+
+@router.delete(
+    "/{post_id}/participate",
+    response_model=ParticipationMessageResponse,
+    description="참여 취소",
+)
+async def cancel_participation(
+    post_id: str,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> ParticipationMessageResponse:
+    """모구 게시물 참여를 취소합니다."""
+
+    # 참여 신청 조회
+    query = select(Participation).where(
+        and_(
+            Participation.mogu_post_id == post_id,
+            Participation.user_id == current_user.id,
+        )
+    )
+    result = await session.execute(query)
+    participation = result.scalar_one_or_none()
+
+    if not participation:
+        raise HTTPException(
+            status_code=404,
+            detail="참여 신청을 찾을 수 없습니다.",
+        )
+
+    # 취소 가능한 상태인지 확인
+    if participation.status not in [
+        ParticipationStatusEnum.APPLIED,
+        ParticipationStatusEnum.ACCEPTED,
+    ]:
+        raise HTTPException(
+            status_code=400,
+            detail="취소할 수 없는 상태입니다.",
+        )
+
+    # 참여 취소
+    participation.status = ParticipationStatusEnum.CANCELED
+    participation.decided_at = datetime.utcnow()
+
+    await session.commit()
+
+    return ParticipationMessageResponse(
+        message="참여가 취소되었습니다.",
+    )
+
+
+@router.get(
+    "/{post_id}/participants",
+    response_model=ParticipationListResponse,
+    description="참여자 목록 조회 (모구장용)",
+)
+async def get_participants(
+    post_id: str,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> ParticipationListResponse:
+    """모구 게시물의 참여자 목록을 조회합니다 (모구장만)."""
+
+    # 게시물 조회
+    query = select(MoguPost).where(MoguPost.id == post_id)
+    result = await session.execute(query)
+    mogu_post = result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    # 모구장 권한 확인
+    if mogu_post.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="모구장만 참여자 목록을 조회할 수 있습니다.",
+        )
+
+    # 참여자 목록 조회
+    participants_query = (
+        select(Participation)
+        .options(selectinload(Participation.user))
+        .where(Participation.mogu_post_id == post_id)
+        .order_by(Participation.applied_at)
+    )
+
+    participants_result = await session.execute(participants_query)
+    participants = participants_result.scalars().all()
+
+    participants_data = []
+    for participation in participants:
+        participants_data.append(
+            ParticipationWithUserResponse(
+                user_id=participation.user_id,
+                status=participation.status,
+                applied_at=participation.applied_at,
+                decided_at=participation.decided_at,
+                user={
+                    "id": participation.user.id,
+                    "nickname": participation.user.nickname,
+                    "profile_image_url": participation.user.profile_image_url,
+                },
+            )
+        )
+
+    return ParticipationListResponse(participants=participants_data)
+
+
+@router.patch(
+    "/{post_id}/participants/{user_id}",
+    response_model=ParticipationMessageResponse,
+    description="참여 승인/거부 (모구장용)",
+)
+async def update_participation_status(
+    post_id: str,
+    user_id: str,
+    data: ParticipationStatusUpdateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> ParticipationMessageResponse:
+    """참여 요청을 승인하거나 거부합니다 (모구장만)."""
+
+    # 게시물 조회
+    query = select(MoguPost).where(MoguPost.id == post_id)
+    result = await session.execute(query)
+    mogu_post = result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    # 모구장 권한 확인
+    if mogu_post.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="모구장만 참여 요청을 승인/거부할 수 있습니다.",
+        )
+
+    # 참여 신청 조회
+    participation_query = select(Participation).where(
+        and_(
+            Participation.mogu_post_id == post_id,
+            Participation.user_id == user_id,
+        )
+    )
+    participation_result = await session.execute(participation_query)
+    participation = participation_result.scalar_one_or_none()
+
+    if not participation:
+        raise HTTPException(
+            status_code=404,
+            detail="참여 신청을 찾을 수 없습니다.",
+        )
+
+    # 승인/거부 가능한 상태인지 확인
+    if participation.status != ParticipationStatusEnum.APPLIED:
+        raise HTTPException(
+            status_code=400,
+            detail="승인/거부할 수 없는 상태입니다.",
+        )
+
+    # 상태 업데이트
+    if data.status == "accepted":
+        participation.status = ParticipationStatusEnum.ACCEPTED
+        message = "참여 요청이 승인되었습니다."
+    elif data.status == "rejected":
+        participation.status = ParticipationStatusEnum.REJECTED
+        message = "참여 요청이 거부되었습니다."
+    else:
+        raise HTTPException(
+            status_code=400,
+            detail="올바르지 않은 상태입니다. 'accepted' 또는 'rejected'를 입력하세요.",
+        )
+
+    participation.decided_at = datetime.utcnow()
+    await session.commit()
+
+    return ParticipationMessageResponse(
+        message=message,
+        participation=ParticipationResponse(
+            user_id=participation.user_id,
+            mogu_post_id=participation.mogu_post_id,
+            status=participation.status,
+            applied_at=participation.applied_at,
+            decided_at=participation.decided_at,
+        ),
+    )

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -163,3 +163,10 @@ class MoguPostListQueryParams(BaseRequest):
     latitude: float  # 필수 파라미터로 변경
     longitude: float  # 필수 파라미터로 변경
     radius: float = 3.0
+
+
+# 참여 관련 Request 스키마
+class ParticipationStatusUpdateRequest(BaseRequest):
+    """참여 상태 업데이트 (승인/거부)"""
+
+    status: str  # "accepted" 또는 "rejected"

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -168,6 +168,6 @@ class MoguPostListQueryParams(BaseRequest):
 
 # 참여 관련 Request 스키마
 class ParticipationStatusUpdateRequest(BaseRequest):
-    """참여 상태 업데이트 (승인/거부)"""
+    """참여 상태 업데이트 (승인/거부/노쇼/완료)"""
 
-    status: str  # "accepted" 또는 "rejected"
+    status: str  # "accepted", "rejected", "no_show", "fulfilled"

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -134,6 +134,7 @@ class MoguPostUpdateRequest(BaseRequest):
     mogu_spot: MoguSpotRequest | None = None
     mogu_datetime: datetime | None = None
     target_count: int | None = None
+    status: str | None = None  # PostStatusEnum 값
     images: list[MoguPostImageRequest] | None = None
 
     @field_validator("target_count")

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -176,8 +176,22 @@ class MoguPostListItemResponse(BaseResponse):
     favorite_count: int  # 찜하기 개수
 
 
+class MoguPostWithParticipationResponse(MoguPostListItemResponse):
+    """참여 정보가 포함된 모구 게시물 응답 스키마"""
+
+    # 참여 정보
+    my_participation_status: str
+    my_participation_applied_at: datetime
+    my_participation_decided_at: datetime | None = None
+
+
 class MoguPostListPaginatedResponse(BaseResponse):
     posts: list[MoguPostListItemResponse]
+    pagination: dict[str, int]
+
+
+class MoguPostWithParticipationPaginatedResponse(BaseResponse):
+    posts: list[MoguPostWithParticipationResponse]
     pagination: dict[str, int]
 
 

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -179,3 +179,29 @@ class MoguPostListItemResponse(BaseResponse):
 class MoguPostListPaginatedResponse(BaseResponse):
     posts: list[MoguPostListItemResponse]
     pagination: dict[str, int]
+
+
+# 참여 관련 Response 스키마
+class ParticipationResponse(BaseResponse):
+    user_id: str
+    mogu_post_id: str
+    status: str
+    applied_at: datetime
+    decided_at: datetime | None = None
+
+
+class ParticipationWithUserResponse(BaseResponse):
+    user_id: str
+    status: str
+    applied_at: datetime
+    decided_at: datetime | None = None
+    user: dict[str, str | None]
+
+
+class ParticipationListResponse(BaseResponse):
+    participants: list[ParticipationWithUserResponse]
+
+
+class ParticipationMessageResponse(BaseResponse):
+    message: str
+    participation: ParticipationResponse | None = None


### PR DESCRIPTION
# ✋ 참여 상태 관리 기능 확장 및 게시글 상태별 처리 개선

## 🔧 주요 개선사항

### **1. 참여 상태 관리 API 확장**
- **기존 API 확장**: `PATCH /api/mogu-posts/{post_id}/participants/{user_id}` API를 승인/거부에서 전체 참여 상태 관리로 확장
- **새로운 상태 지원**: `no_show`, `fulfilled` 상태 추가
- **상태 변경 제약**: 각 상태별 허용되는 이전 상태를 명시적으로 정의

### **2. 모구 게시물 상태 변경 시 참여자 처리 개선**
- **게시물 취소 시**: 모든 참여자 → `CANCELED` (기존: ACCEPTED만 처리)
- **게시물 완료 시**: 
  - `ACCEPTED` → `FULFILLED` (기본값)
  - `APPLIED` → `CANCELED` (미처리 요청 취소)
- **노쇼 처리**: 모구 완료 후 별도 API로 `FULFILLED` → `NO_SHOW` 변경 가능

### **3. 참여 요청 시 게시물 상태 검증 강화**
- **상태별 차단**: `LOCKED`, `PURCHASING`, `DISTRIBUTING`, `COMPLETED`, `CANCELED` 상태에서 참여 요청 차단
- **상태별 메시지**: 각 상태에 맞는 구체적인 에러 메시지 제공
- **참여 승인/거부 제한**: `RECRUITING`, `LOCKED` 상태에서만 참여 승인/거부 가능

### **4. 참여 재신청 로직 개선**
- **재신청 허용**: `REJECTED`, `CANCELED` 상태에서 재신청 가능
- **기존 기록 활용**: 새로 생성하지 않고 기존 `Participation` 기록 업데이트
- **타임스탬프 관리**: 재신청 시 `applied_at` 갱신, `decided_at` 초기화

## 📊 상태 변경 플로우

```
참여 요청 (APPLIED) → 승인 (ACCEPTED) → 완료 (FULFILLED)
                   ↘ 거부 (REJECTED)    ↘ 노쇼 (NO_SHOW)
                   ↘ 재신청 가능        ↘ 완료 처리 가능
```

## 🛡️ 데이터 일관성 보장

- **`joined_count` 동기화**: 참여 승인/취소 시 정확한 카운트 유지
- **상태 변경 검증**: 각 상태 변경 시 허용 가능한 이전 상태 확인
- **게시물 상태 연동**: 게시물 상태 변경 시 참여자 상태 자동 처리

## 🔍 API 사용 예시

```javascript
// 노쇼 처리 (모구 완료 후)
await api.patch(`/api/mogu-posts/${postId}/participants/${userId}`, {
  status: "no_show"
});

// 완료 처리 (노쇼 해제)
await api.patch(`/api/mogu-posts/${postId}/participants/${userId}`, {
  status: "fulfilled"
});

// 재신청 (거부/취소 후)
await api.post(`/api/mogu-posts/${postId}/participate`);
```

## 📝 변경된 파일

- **`app/api/endpoints/participations.py`**: 참여 상태 관리 로직 확장 및 검증 강화
- **`app/api/endpoints/mogu_posts.py`**: 게시물 상태 변경 시 참여자 처리 로직 개선
- **`app/schemas/requests.py`**: 참여 상태 업데이트 스키마 확장
- **`app/schemas/responses.py`**: 새로운 응답 스키마 추가

## ✅ 개선 효과

1. **완전한 참여 생명주기 관리**: 모구 생성부터 완료까지 모든 상태 처리
2. **유연한 노쇼 처리**: 모구 완료 후 개별 참여자 노쇼 처리 가능
3. **강화된 검증**: 상태별 명확한 제약 조건으로 데이터 무결성 보장
4. **사용자 경험 개선**: 재신청 허용으로 사용자 편의성 향상