### PR TITLE
Backend/api question and answer

### DIFF
--- a/app/api/api_router.py
+++ b/app/api/api_router.py
@@ -1,7 +1,7 @@
 from fastapi import APIRouter
 
 from app.api import api_messages
-from app.api.endpoints import auth, mogu_posts, participations, users
+from app.api.endpoints import auth, mogu_posts, participations, questions, users
 
 auth_router = APIRouter()
 auth_router.include_router(auth.router, prefix="/auth", tags=["auth"])
@@ -36,3 +36,4 @@ api_router.include_router(mogu_posts.router, prefix="/mogu-posts", tags=["mogu-p
 api_router.include_router(
     participations.router, prefix="/mogu-posts", tags=["participations"]
 )
+api_router.include_router(questions.router, prefix="/mogu-posts", tags=["questions"])

--- a/app/api/endpoints/questions.py
+++ b/app/api/endpoints/questions.py
@@ -17,7 +17,6 @@ from app.schemas.requests import (
 )
 from app.schemas.responses import (
     QuestionListResponse,
-    QuestionMessageResponse,
     QuestionResponse,
     QuestionWithAnswerResponse,
 )
@@ -85,7 +84,7 @@ async def _get_question(
 
 @router.post(
     "/{post_id}/questions",
-    response_model=QuestionMessageResponse,
+    response_model=QuestionResponse,
     description="질문 작성",
 )
 async def create_question(
@@ -93,7 +92,7 @@ async def create_question(
     data: QuestionCreateRequest,
     current_user: User = Depends(deps.get_current_user),
     session: AsyncSession = Depends(get_async_session),
-) -> QuestionMessageResponse:
+) -> QuestionResponse:
     """모구 게시물에 질문을 작성합니다."""
 
     # 게시물 조회 및 상태 확인
@@ -116,21 +115,18 @@ async def create_question(
     # 질문자 정보 로드
     await session.refresh(question, ["questioner"])
 
-    return QuestionMessageResponse(
-        message="질문이 작성되었습니다.",
-        question=QuestionResponse(
-            id=question.id,
-            mogu_post_id=question.mogu_post_id,
-            questioner_id=question.questioner_id,
-            question=question.question,
-            is_private=question.is_private,
-            question_created_at=question.question_created_at,
-            questioner={
-                "id": question.questioner.id,
-                "nickname": question.questioner.nickname,
-                "profile_image_url": question.questioner.profile_image_url,
-            },
-        ),
+    return QuestionResponse(
+        id=question.id,
+        mogu_post_id=question.mogu_post_id,
+        questioner_id=question.questioner_id,
+        question=question.question,
+        is_private=question.is_private,
+        question_created_at=question.question_created_at,
+        questioner={
+            "id": question.questioner.id,
+            "nickname": question.questioner.nickname,
+            "profile_image_url": question.questioner.profile_image_url,
+        },
     )
 
 

--- a/app/api/endpoints/questions.py
+++ b/app/api/endpoints/questions.py
@@ -193,6 +193,7 @@ async def update_question(
 
 @router.delete(
     "/{post_id}/questions/{question_id}",
+    status_code=204,
     description="질문 삭제",
 )
 async def delete_question(
@@ -200,7 +201,7 @@ async def delete_question(
     question_id: str,
     current_user: User = Depends(deps.get_current_user),
     session: AsyncSession = Depends(get_async_session),
-) -> dict[str, str]:
+) -> None:
     """질문을 삭제합니다 (답변이 달리기 전까지만 가능)."""
 
     # 질문 조회
@@ -227,8 +228,6 @@ async def delete_question(
     # 질문 삭제
     await session.delete(question)
     await session.commit()
-
-    return {"message": "질문이 삭제되었습니다."}
 
 
 @router.post(
@@ -373,6 +372,7 @@ async def update_answer(
 
 @router.delete(
     "/{post_id}/questions/{question_id}/answer",
+    status_code=204,
     description="답변 삭제 (모구장용)",
 )
 async def delete_answer(
@@ -380,7 +380,7 @@ async def delete_answer(
     question_id: str,
     current_user: User = Depends(deps.get_current_user),
     session: AsyncSession = Depends(get_async_session),
-) -> dict[str, str]:
+) -> None:
     """답변을 삭제합니다 (모구장만, 모구 완료/취소 전까지)."""
 
     # 게시물 조회 및 상태 확인
@@ -410,8 +410,6 @@ async def delete_answer(
     question.answer_created_at = None
 
     await session.commit()
-
-    return {"message": "답변이 삭제되었습니다."}
 
 
 @router.get(

--- a/app/api/endpoints/questions.py
+++ b/app/api/endpoints/questions.py
@@ -1,0 +1,244 @@
+from datetime import datetime
+
+from fastapi import APIRouter, Depends, HTTPException
+from sqlalchemy import and_, select
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy.orm import selectinload
+
+from app.api import api_messages, deps
+from app.core.database_session import get_async_session
+from app.enums import PostStatusEnum
+from app.models import MoguPost, QuestionAnswer, User
+from app.schemas.requests import AnswerCreateRequest, QuestionCreateRequest
+from app.schemas.responses import (
+    QuestionListResponse,
+    QuestionMessageResponse,
+    QuestionResponse,
+    QuestionWithAnswerResponse,
+)
+
+router = APIRouter()
+
+
+@router.post(
+    "/{post_id}/questions",
+    response_model=QuestionMessageResponse,
+    description="질문 작성",
+)
+async def create_question(
+    post_id: str,
+    data: QuestionCreateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> QuestionMessageResponse:
+    """모구 게시물에 질문을 작성합니다."""
+
+    # 게시물 조회
+    query = select(MoguPost).where(MoguPost.id == post_id)
+    result = await session.execute(query)
+    mogu_post = result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    # 질문 작성 가능한 상태인지 확인
+    if mogu_post.status == PostStatusEnum.CANCELED.value:
+        raise HTTPException(
+            status_code=400,
+            detail="취소된 모구에는 질문할 수 없습니다.",
+        )
+
+    # 질문 생성
+    question = QuestionAnswer(
+        mogu_post_id=post_id,
+        questioner_id=current_user.id,
+        question=data.question,
+        is_private=data.is_private,
+        question_created_at=datetime.utcnow(),
+    )
+
+    session.add(question)
+    await session.commit()
+    await session.refresh(question)
+
+    # 질문자 정보 로드
+    await session.refresh(question, ["questioner"])
+
+    return QuestionMessageResponse(
+        message="질문이 작성되었습니다.",
+        question=QuestionResponse(
+            id=question.id,
+            mogu_post_id=question.mogu_post_id,
+            questioner_id=question.questioner_id,
+            question=question.question,
+            is_private=question.is_private,
+            question_created_at=question.question_created_at,
+            questioner={
+                "id": question.questioner.id,
+                "nickname": question.questioner.nickname,
+                "profile_image_url": question.questioner.profile_image_url,
+            },
+        ),
+    )
+
+
+@router.post(
+    "/{post_id}/questions/{question_id}/answer",
+    response_model=QuestionWithAnswerResponse,
+    description="답변 작성 (모구장용)",
+)
+async def create_answer(
+    post_id: str,
+    question_id: str,
+    data: AnswerCreateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> QuestionWithAnswerResponse:
+    """질문에 답변을 작성합니다 (모구장만)."""
+
+    # 게시물 조회
+    mogu_post_query = select(MoguPost).where(MoguPost.id == post_id)
+    mogu_post_result = await session.execute(mogu_post_query)
+    mogu_post = mogu_post_result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    # 모구장 권한 확인
+    if mogu_post.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="모구장만 답변을 작성할 수 있습니다.",
+        )
+
+    # 질문 조회
+    question_query = select(QuestionAnswer).where(
+        and_(
+            QuestionAnswer.id == question_id,
+            QuestionAnswer.mogu_post_id == post_id,
+        )
+    )
+    question_result = await session.execute(question_query)
+    question = question_result.scalar_one_or_none()
+
+    if not question:
+        raise HTTPException(
+            status_code=404,
+            detail="질문을 찾을 수 없습니다.",
+        )
+
+    # 이미 답변이 있는지 확인
+    if question.answer is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="이미 답변이 작성된 질문입니다.",
+        )
+
+    # 답변 업데이트
+    question.answer = data.answer
+    question.answerer_id = current_user.id
+    question.answer_created_at = datetime.utcnow()
+
+    await session.commit()
+    await session.refresh(question)
+
+    # 관련 데이터 로드
+    await session.refresh(question, ["questioner", "answerer"])
+
+    # 답변자 정보 구성
+    answerer_data = None
+    if question.answerer:
+        answerer_data = {
+            "id": question.answerer.id,
+            "nickname": question.answerer.nickname,
+            "profile_image_url": question.answerer.profile_image_url,
+        }
+
+    return QuestionWithAnswerResponse(
+        id=question.id,
+        question=question.question,
+        answer=question.answer,
+        is_private=question.is_private,
+        question_created_at=question.question_created_at,
+        answer_created_at=question.answer_created_at,
+        questioner={
+            "id": question.questioner.id,
+            "nickname": question.questioner.nickname,
+            "profile_image_url": question.questioner.profile_image_url,
+        },
+        answerer=answerer_data,
+    )
+
+
+@router.get(
+    "/{post_id}/questions",
+    response_model=QuestionListResponse,
+    description="Q&A 목록 조회",
+)
+async def get_questions(
+    post_id: str,
+    current_user: User | None = Depends(deps.get_current_user_optional),
+    session: AsyncSession = Depends(get_async_session),
+) -> QuestionListResponse:
+    """모구 게시물의 Q&A 목록을 조회합니다."""
+
+    # 게시물 조회
+    query = select(MoguPost).where(MoguPost.id == post_id)
+    result = await session.execute(query)
+    mogu_post = result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    # Q&A 목록 조회
+    questions_query = (
+        select(QuestionAnswer)
+        .options(
+            selectinload(QuestionAnswer.questioner),
+            selectinload(QuestionAnswer.answerer),
+        )
+        .where(QuestionAnswer.mogu_post_id == post_id)
+        .order_by(QuestionAnswer.question_created_at.desc())
+    )
+
+    questions_result = await session.execute(questions_query)
+    questions = questions_result.scalars().all()
+
+    questions_data = []
+    for question in questions:
+        # 답변자 정보 구성
+        answerer_data = None
+        if question.answerer:
+            answerer_data = {
+                "id": question.answerer.id,
+                "nickname": question.answerer.nickname,
+                "profile_image_url": question.answerer.profile_image_url,
+            }
+
+        questions_data.append(
+            QuestionWithAnswerResponse(
+                id=question.id,
+                question=question.question,
+                answer=question.answer,
+                is_private=question.is_private,
+                question_created_at=question.question_created_at,
+                answer_created_at=question.answer_created_at,
+                questioner={
+                    "id": question.questioner.id,
+                    "nickname": question.questioner.nickname,
+                    "profile_image_url": question.questioner.profile_image_url,
+                },
+                answerer=answerer_data,
+            )
+        )
+
+    return QuestionListResponse(questions=questions_data)

--- a/app/api/endpoints/questions.py
+++ b/app/api/endpoints/questions.py
@@ -9,7 +9,12 @@ from app.api import api_messages, deps
 from app.core.database_session import get_async_session
 from app.enums import PostStatusEnum
 from app.models import MoguPost, QuestionAnswer, User
-from app.schemas.requests import AnswerCreateRequest, QuestionCreateRequest
+from app.schemas.requests import (
+    AnswerCreateRequest,
+    AnswerUpdateRequest,
+    QuestionCreateRequest,
+    QuestionUpdateRequest,
+)
 from app.schemas.responses import (
     QuestionListResponse,
     QuestionMessageResponse,
@@ -18,6 +23,64 @@ from app.schemas.responses import (
 )
 
 router = APIRouter()
+
+
+async def _get_mogu_post(
+    post_id: str,
+    session: AsyncSession,
+) -> MoguPost:
+    """모구 게시물을 조회합니다."""
+    query = select(MoguPost).where(MoguPost.id == post_id)
+    result = await session.execute(query)
+    mogu_post = result.scalar_one_or_none()
+
+    if not mogu_post:
+        raise HTTPException(
+            status_code=404,
+            detail=api_messages.MOGU_POST_NOT_FOUND,
+        )
+
+    return mogu_post
+
+
+async def _check_qa_activity_allowed(
+    mogu_post: MoguPost,
+    session: AsyncSession,
+) -> None:
+    """Q&A 활동이 허용되는 상태인지 확인합니다."""
+    if mogu_post.status in [
+        PostStatusEnum.DRAFT.value,
+        PostStatusEnum.CANCELED.value,
+        PostStatusEnum.COMPLETED.value,
+    ]:
+        raise HTTPException(
+            status_code=400,
+            detail="현재 Q&A 활동을 할 수 없는 상태입니다.",
+        )
+
+
+async def _get_question(
+    post_id: str,
+    question_id: str,
+    session: AsyncSession,
+) -> QuestionAnswer:
+    """질문을 조회합니다."""
+    question_query = select(QuestionAnswer).where(
+        and_(
+            QuestionAnswer.id == question_id,
+            QuestionAnswer.mogu_post_id == post_id,
+        )
+    )
+    question_result = await session.execute(question_query)
+    question = question_result.scalar_one_or_none()
+
+    if not question:
+        raise HTTPException(
+            status_code=404,
+            detail="질문을 찾을 수 없습니다.",
+        )
+
+    return question
 
 
 @router.post(
@@ -33,23 +96,9 @@ async def create_question(
 ) -> QuestionMessageResponse:
     """모구 게시물에 질문을 작성합니다."""
 
-    # 게시물 조회
-    query = select(MoguPost).where(MoguPost.id == post_id)
-    result = await session.execute(query)
-    mogu_post = result.scalar_one_or_none()
-
-    if not mogu_post:
-        raise HTTPException(
-            status_code=404,
-            detail=api_messages.MOGU_POST_NOT_FOUND,
-        )
-
-    # 질문 작성 가능한 상태인지 확인
-    if mogu_post.status == PostStatusEnum.CANCELED.value:
-        raise HTTPException(
-            status_code=400,
-            detail="취소된 모구에는 질문할 수 없습니다.",
-        )
+    # 게시물 조회 및 상태 확인
+    mogu_post = await _get_mogu_post(post_id, session)
+    await _check_qa_activity_allowed(mogu_post, session)
 
     # 질문 생성
     question = QuestionAnswer(
@@ -85,6 +134,107 @@ async def create_question(
     )
 
 
+@router.patch(
+    "/{post_id}/questions/{question_id}",
+    response_model=QuestionResponse,
+    description="질문 수정",
+)
+async def update_question(
+    post_id: str,
+    question_id: str,
+    data: QuestionUpdateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> QuestionResponse:
+    """질문을 수정합니다 (답변이 달리기 전까지만 가능)."""
+
+    # 질문 조회
+    question = await _get_question(post_id, question_id, session)
+
+    # 질문 작성자 권한 확인
+    if question.questioner_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="질문 작성자만 수정할 수 있습니다.",
+        )
+
+    # 게시물 상태 확인
+    mogu_post = await _get_mogu_post(post_id, session)
+    await _check_qa_activity_allowed(mogu_post, session)
+
+    # 답변이 이미 달렸는지 확인
+    if question.answer is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="답변이 달린 질문은 수정할 수 없습니다.",
+        )
+
+    # 질문 업데이트
+    question.question = data.question
+    if data.is_private is not None:
+        question.is_private = data.is_private
+
+    await session.commit()
+    await session.refresh(question)
+
+    # 질문자 정보 로드
+    await session.refresh(question, ["questioner"])
+
+    return QuestionResponse(
+        id=question.id,
+        mogu_post_id=question.mogu_post_id,
+        questioner_id=question.questioner_id,
+        question=question.question,
+        is_private=question.is_private,
+        question_created_at=question.question_created_at,
+        questioner={
+            "id": question.questioner.id,
+            "nickname": question.questioner.nickname,
+            "profile_image_url": question.questioner.profile_image_url,
+        },
+    )
+
+
+@router.delete(
+    "/{post_id}/questions/{question_id}",
+    description="질문 삭제",
+)
+async def delete_question(
+    post_id: str,
+    question_id: str,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, str]:
+    """질문을 삭제합니다 (답변이 달리기 전까지만 가능)."""
+
+    # 질문 조회
+    question = await _get_question(post_id, question_id, session)
+
+    # 질문 작성자 권한 확인
+    if question.questioner_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="질문 작성자만 삭제할 수 있습니다.",
+        )
+
+    # 게시물 상태 확인
+    mogu_post = await _get_mogu_post(post_id, session)
+    await _check_qa_activity_allowed(mogu_post, session)
+
+    # 답변이 이미 달렸는지 확인
+    if question.answer is not None:
+        raise HTTPException(
+            status_code=400,
+            detail="답변이 달린 질문은 삭제할 수 없습니다.",
+        )
+
+    # 질문 삭제
+    await session.delete(question)
+    await session.commit()
+
+    return {"message": "질문이 삭제되었습니다."}
+
+
 @router.post(
     "/{post_id}/questions/{question_id}/answer",
     response_model=QuestionWithAnswerResponse,
@@ -99,16 +249,9 @@ async def create_answer(
 ) -> QuestionWithAnswerResponse:
     """질문에 답변을 작성합니다 (모구장만)."""
 
-    # 게시물 조회
-    mogu_post_query = select(MoguPost).where(MoguPost.id == post_id)
-    mogu_post_result = await session.execute(mogu_post_query)
-    mogu_post = mogu_post_result.scalar_one_or_none()
-
-    if not mogu_post:
-        raise HTTPException(
-            status_code=404,
-            detail=api_messages.MOGU_POST_NOT_FOUND,
-        )
+    # 게시물 조회 및 상태 확인
+    mogu_post = await _get_mogu_post(post_id, session)
+    await _check_qa_activity_allowed(mogu_post, session)
 
     # 모구장 권한 확인
     if mogu_post.user_id != current_user.id:
@@ -118,20 +261,7 @@ async def create_answer(
         )
 
     # 질문 조회
-    question_query = select(QuestionAnswer).where(
-        and_(
-            QuestionAnswer.id == question_id,
-            QuestionAnswer.mogu_post_id == post_id,
-        )
-    )
-    question_result = await session.execute(question_query)
-    question = question_result.scalar_one_or_none()
-
-    if not question:
-        raise HTTPException(
-            status_code=404,
-            detail="질문을 찾을 수 없습니다.",
-        )
+    question = await _get_question(post_id, question_id, session)
 
     # 이미 답변이 있는지 확인
     if question.answer is not None:
@@ -176,6 +306,118 @@ async def create_answer(
     )
 
 
+@router.patch(
+    "/{post_id}/questions/{question_id}/answer",
+    response_model=QuestionWithAnswerResponse,
+    description="답변 수정 (모구장용)",
+)
+async def update_answer(
+    post_id: str,
+    question_id: str,
+    data: AnswerUpdateRequest,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> QuestionWithAnswerResponse:
+    """답변을 수정합니다 (모구장만, 모구 완료/취소 전까지)."""
+
+    # 게시물 조회 및 상태 확인
+    mogu_post = await _get_mogu_post(post_id, session)
+    await _check_qa_activity_allowed(mogu_post, session)
+
+    # 모구장 권한 확인
+    if mogu_post.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="모구장만 답변을 수정할 수 있습니다.",
+        )
+
+    # 질문 조회
+    question = await _get_question(post_id, question_id, session)
+
+    # 답변이 있는지 확인
+    if question.answer is None:
+        raise HTTPException(
+            status_code=400,
+            detail="답변이 없는 질문입니다.",
+        )
+
+    # 답변 수정
+    question.answer = data.answer
+
+    await session.commit()
+    await session.refresh(question)
+
+    # 관련 데이터 로드
+    await session.refresh(question, ["questioner", "answerer"])
+
+    # 답변자 정보 구성
+    answerer_data = None
+    if question.answerer:
+        answerer_data = {
+            "id": question.answerer.id,
+            "nickname": question.answerer.nickname,
+            "profile_image_url": question.answerer.profile_image_url,
+        }
+
+    return QuestionWithAnswerResponse(
+        id=question.id,
+        question=question.question,
+        answer=question.answer,
+        is_private=question.is_private,
+        question_created_at=question.question_created_at,
+        answer_created_at=question.answer_created_at,
+        questioner={
+            "id": question.questioner.id,
+            "nickname": question.questioner.nickname,
+            "profile_image_url": question.questioner.profile_image_url,
+        },
+        answerer=answerer_data,
+    )
+
+
+@router.delete(
+    "/{post_id}/questions/{question_id}/answer",
+    description="답변 삭제 (모구장용)",
+)
+async def delete_answer(
+    post_id: str,
+    question_id: str,
+    current_user: User = Depends(deps.get_current_user),
+    session: AsyncSession = Depends(get_async_session),
+) -> dict[str, str]:
+    """답변을 삭제합니다 (모구장만, 모구 완료/취소 전까지)."""
+
+    # 게시물 조회 및 상태 확인
+    mogu_post = await _get_mogu_post(post_id, session)
+    await _check_qa_activity_allowed(mogu_post, session)
+
+    # 모구장 권한 확인
+    if mogu_post.user_id != current_user.id:
+        raise HTTPException(
+            status_code=403,
+            detail="모구장만 답변을 삭제할 수 있습니다.",
+        )
+
+    # 질문 조회
+    question = await _get_question(post_id, question_id, session)
+
+    # 답변이 있는지 확인
+    if question.answer is None:
+        raise HTTPException(
+            status_code=400,
+            detail="답변이 없는 질문입니다.",
+        )
+
+    # 답변 삭제 (답변 관련 필드만 초기화)
+    question.answer = None
+    question.answerer_id = None
+    question.answer_created_at = None
+
+    await session.commit()
+
+    return {"message": "답변이 삭제되었습니다."}
+
+
 @router.get(
     "/{post_id}/questions",
     response_model=QuestionListResponse,
@@ -188,7 +430,7 @@ async def get_questions(
 ) -> QuestionListResponse:
     """모구 게시물의 Q&A 목록을 조회합니다."""
 
-    # 게시물 조회
+    # 게시물 존재 확인
     query = select(MoguPost).where(MoguPost.id == post_id)
     result = await session.execute(query)
     mogu_post = result.scalar_one_or_none()

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -171,3 +171,17 @@ class ParticipationStatusUpdateRequest(BaseRequest):
     """참여 상태 업데이트 (승인/거부/노쇼/완료)"""
 
     status: str  # "accepted", "rejected", "no_show", "fulfilled"
+
+
+# Q&A 관련 Request 스키마
+class QuestionCreateRequest(BaseRequest):
+    """질문 작성"""
+
+    question: str
+    is_private: bool = False
+
+
+class AnswerCreateRequest(BaseRequest):
+    """답변 작성"""
+
+    answer: str

--- a/app/schemas/requests.py
+++ b/app/schemas/requests.py
@@ -185,3 +185,16 @@ class AnswerCreateRequest(BaseRequest):
     """답변 작성"""
 
     answer: str
+
+
+class QuestionUpdateRequest(BaseRequest):
+    """질문 수정"""
+
+    question: str
+    is_private: bool | None = None
+
+
+class AnswerUpdateRequest(BaseRequest):
+    """답변 수정"""
+
+    answer: str

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -245,8 +245,3 @@ class QuestionWithAnswerResponse(BaseResponse):
 
 class QuestionListResponse(BaseResponse):
     questions: list[QuestionWithAnswerResponse]
-
-
-class QuestionMessageResponse(BaseResponse):
-    message: str
-    question: QuestionResponse | None = None

--- a/app/schemas/responses.py
+++ b/app/schemas/responses.py
@@ -219,3 +219,34 @@ class ParticipationListResponse(BaseResponse):
 class ParticipationMessageResponse(BaseResponse):
     message: str
     participation: ParticipationResponse | None = None
+
+
+# Q&A 관련 Response 스키마
+class QuestionResponse(BaseResponse):
+    id: str
+    mogu_post_id: str
+    questioner_id: str
+    question: str
+    is_private: bool
+    question_created_at: datetime
+    questioner: dict[str, str | None]
+
+
+class QuestionWithAnswerResponse(BaseResponse):
+    id: str
+    question: str
+    answer: str | None = None
+    is_private: bool
+    question_created_at: datetime
+    answer_created_at: datetime | None = None
+    questioner: dict[str, str | None]
+    answerer: dict[str, str | None] | None = None
+
+
+class QuestionListResponse(BaseResponse):
+    questions: list[QuestionWithAnswerResponse]
+
+
+class QuestionMessageResponse(BaseResponse):
+    message: str
+    question: QuestionResponse | None = None


### PR DESCRIPTION
# 🎯 Q&A API 구현

## 📝 주요 변경사항

### 1. Q&A API 완전 구현
- 질문 작성/수정/삭제 API 구현
- 답변 작성/수정/삭제 API 구현  
- Q&A 목록 조회 API 구현
- 채팅 대신 사용되는 Q&A 시스템으로 설계

### 2. 코드 품질 개선
- 중복 코드 제거 (80줄 이상 축약)
- 공통 함수 추출 (`_get_mogu_post`, `_check_qa_activity_allowed`, `_get_question`)
- Python 관례 준수 (내부 함수 `_` prefix)

## 🔧 구현된 API 목록

| API | Method | URI | 설명 |
|-----|--------|-----|------|
| 질문 작성 | POST | `/api/mogu-posts/{post_id}/questions` | 모구 게시물에 질문 작성 |
| 질문 수정 | PATCH | `/api/mogu-posts/{post_id}/questions/{question_id}` | 질문 수정 (답변 전까지만) |
| 질문 삭제 | DELETE | `/api/mogu-posts/{post_id}/questions/{question_id}` | 질문 삭제 (답변 전까지만) |
| 답변 작성 | POST | `/api/mogu-posts/{post_id}/questions/{question_id}/answer` | 답변 작성 (모구장만) |
| 답변 수정 | PATCH | `/api/mogu-posts/{post_id}/questions/{question_id}/answer` | 답변 수정 (모구장만) |
| 답변 삭제 | DELETE | `/api/mogu-posts/{post_id}/questions/{question_id}/answer` | 답변 삭제 (모구장만) |
| Q&A 목록 조회 | GET | `/api/mogu-posts/{post_id}/questions` | Q&A 목록 조회 |

## 📋 Q&A 관리 정책

### 게시물 상태별 Q&A 활동 허용:
- `DRAFT`: 모든 Q&A 활동 불가
- `RECRUITING`, `LOCKED`, `PURCHASING`, `DISTRIBUTING`: 모든 Q&A 활동 가능
- `CANCELED`, `COMPLETED`: 모든 Q&A 활동 불가

### 권한 관리:
- 질문: 질문 작성자만 수정/삭제 가능
- 답변: 모구장만 작성/수정/삭제 가능

### 비즈니스 로직:
- 질문: 답변이 달리기 전까지만 수정/삭제 가능
- 답변: 모구 완료/취소 전까지만 수정/삭제 가능
- 비공개 질문: 프론트에서 필터링 처리

## **📚 추가 문서**

- `docs/rest-api-design-rules.md`: REST API 설계 규칙 및 모범 사례 정립

## **📊 변경 통계**

```
6 files changed, 712 insertions(+), 20 deletions(-)
```

## **🎯 기대 효과**

1. **사용자 경험**: 채팅처럼 자유로운 Q&A 소통 환경 제공
2. **개발 효율성**: 중복 코드 제거로 유지보수성 향상
3. **API 일관성**: REST API 모범 사례 준수로 표준화
4. **확장성**: 공통 함수로 향후 API 개발 효율성 증대

## **🔄 향후 계획**

- 전체 API를 REST API 가이드에 맞춰 일관성 있게 리팩토링
- 중복 코드 제거 및 공통 함수 추출 확대
- API 응답 구조 표준화